### PR TITLE
fix: resolve KeyError in quality_assurance.load_venues

### DIFF
--- a/quality_assurance.py
+++ b/quality_assurance.py
@@ -72,7 +72,7 @@ def normalize_venue(value):
 
 def load_venues():
     data = json.loads(VENUES_FILE.read_text(encoding="utf-8"))
-    return data["venues"]
+    return data
 
 
 def _links(data):
@@ -239,11 +239,13 @@ def main():
 
     venues = load_venues()
     title_lookup = {}  # normalized Venue Title (or alias) -> reference entry
-    for entry in venues:
-        for surface in [entry["title"], *entry.get("aliases", [])]:
+    for canonical_title, entry in venues.items():
+        # The dict key is the canonical title; aliases are listed in the entry.
+        enriched = {**entry, "title": canonical_title}
+        for surface in [canonical_title, *entry.get("aliases", [])]:
             k = normalize_venue(surface)
             if k:
-                title_lookup.setdefault(k, entry)
+                title_lookup.setdefault(k, enriched)
     ctx = {"venue_title_lookup": title_lookup}
 
     findings = []  # {"file", "check", "message"}


### PR DESCRIPTION
## Summary

`quality_assurance.py` crashes on startup with `KeyError: 'venues'` because `load_venues()` expects a top-level `venues` key that doesn't exist in `venues.json`.

The actual file is a flat dict keyed by canonical venue title, where each value has `{name, type, aliases}` (no `title` field). The lookup loop then accessed `entry[title]`, which would also KeyError.

## Changes

1. `load_venues()` now returns the parsed JSON object directly instead of accessing a non-existent `venues` key.
2. The title lookup loop iterates `venues.items()` and treats the dict key as the canonical title, merging it into the entry so downstream `entry[title]` lookups still work.

## Verification

- `python3 quality_assurance.py` now runs to completion and scans 1,118 datasets successfully, reporting 23 real issues (0 venue, 0 subset, 1 host, 14 public-derived, 8 authors).
- Pre-fix, the script crashed immediately at `load_venues()` before scanning any file.

— Sent via @AmSach bot