### PR TITLE
Add Mixat dataset (Emirati-English code-switched speech)

### DIFF
--- a/datasets/mixat.json
+++ b/datasets/mixat.json
@@ -1,0 +1,53 @@
+{
+    "Name": "Mixat",
+    "Dialect Subsets": [],
+    "HF Link": "",
+    "Link": "https://github.com/mbzuai-nlp/mixat",
+    "License": "CC BY-NC-SA 4.0",
+    "Year": 2024,
+    "Language": "multilingual",
+    "Dialect": "United Arab Emirates",
+    "Source": [
+        "other"
+    ],
+    "Domain": [
+        "general"
+    ],
+    "Form": "audio",
+    "Annotation Style": [
+        "human annotation"
+    ],
+    "Description": "15-hour Emirati Arabic-English code-switched speech corpus derived from two public podcasts featuring native Emirati speakers, with manual transcriptions. Designed to address the shortcomings of existing ASR systems on bilingual Emirati speech.",
+    "Volume": 15.0,
+    "Unit": "hours",
+    "Ethical Risks": "Low",
+    "Provider": [
+        "MBZUAI"
+    ],
+    "Derived From": [],
+    "Paper Title": "Mixat: A Data Set of Bilingual Emirati-English Speech",
+    "Paper Link": "https://aclanthology.org/2024.sigul-1.26.pdf",
+    "Script": "Arab-Latin",
+    "Tokenized": false,
+    "Host": "GitHub",
+    "Access": "Free",
+    "Cost": "",
+    "Has Splits": false,
+    "Partial": false,
+    "Tasks": [
+        "speech recognition",
+        "codeswitch detection"
+    ],
+    "Venue Title": "LREC-COLING",
+    "Venue Type": "conference",
+    "Venue Name": "Joint International Conference on Computational Linguistics, Language Resources and Evaluation",
+    "Authors": [
+        "Maryam Khalifa Al Ali",
+        "Hanan Aldarmaki"
+    ],
+    "Affiliations": [
+        "MBZUAI"
+    ],
+    "Abstract": "Mixat is a dataset of Emirati speech code-mixed with English, developed to address the limitations of current speech recognition resources when applied to bilingual Emirati speakers who frequently switch between their local dialect and English. It comprises 15 hours of speech drawn from two public podcasts featuring native Emirati speakers, one of which consists of conversations between a host and a guest, capturing code-switching in both formal and natural conversational settings. The authors describe the data collection and annotation process and evaluate several pre-trained Arabic and multilingual ASR systems on the data, highlighting their weaknesses on this low-resource dialectal variety and on code-switched speech in general.",
+    "Added By": "Kareem Tadros"
+}

--- a/datasets/mixat.json
+++ b/datasets/mixat.json
@@ -8,10 +8,10 @@
     "Language": "multilingual",
     "Dialect": "United Arab Emirates",
     "Source": [
-        "other"
+        "podcasts"
     ],
     "Domain": [
-        "general"
+        "sports", "finance", "science", "technology", "health"
     ],
     "Form": "audio",
     "Annotation Style": [
@@ -42,7 +42,7 @@
     "Venue Type": "conference",
     "Venue Name": "Joint International Conference on Computational Linguistics, Language Resources and Evaluation",
     "Authors": [
-        "Maryam Khalifa Al Ali",
+        "Maryam Al Ali",
         "Hanan Aldarmaki"
     ],
     "Affiliations": [

--- a/datasets/mixat.json
+++ b/datasets/mixat.json
@@ -8,7 +8,7 @@
     "Language": "multilingual",
     "Dialect": "United Arab Emirates",
     "Source": [
-        "podcasts"
+        "studio recordings"
     ],
     "Domain": [
         "sports", "finance", "science", "technology", "health"


### PR DESCRIPTION
Adds the Mixat corpus: 15 hours of Emirati Arabic–English code-switched speech collected from two public podcasts featuring native Emirati speakers, with manual transcriptions (Al Ali & Aldarmaki, LREC-COLING 2024 / SIGUL).

- Paper: https://aclanthology.org/2024.sigul-1.26
- Data: https://github.com/mbzuai-nlp/mixat
- License: CC BY-NC-SA 4.0

Validated locally against schema.json with validate_schema.py (passed). Recorded the venue as LREC-COLING since SIGUL isn't in the controlled venue list; happy to adjust any fields on request.